### PR TITLE
Use ubuntu 20.04 to ensure geckodriver is available for selenium

### DIFF
--- a/.github/workflows/sync_to_tolino_cloud.yml
+++ b/.github/workflows/sync_to_tolino_cloud.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   test:
     name: Zeit to Tolino Cloud
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04  # pinned to 20 as 22 was lacking geckodriver
 
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,8 @@
 
 name: Python Tests
 
-on: ["push"]
+on:
+  push:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,12 @@
 
 name: Python Tests
 
-on:
-  push:
+on: ["push"]
 
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04  # pinned to 20 as 22 was lacking geckodriver
 
     steps:
     - name: Checkout
@@ -31,5 +30,4 @@ jobs:
         TOLINO_USER: ${{ secrets.TOLINO_USER }}
         TOLINO_PASSWORD: ${{ secrets.TOLINO_PASSWORD }}
         TOLINO_PARTNER_SHOP: ${{ secrets.TOLINO_PARTNER_SHOP }}
-        GECKOWEBDRIVER: /usr/local/share/gecko_driver
       run: poetry run pytest tests/ -vv --color=yes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,5 @@ jobs:
         TOLINO_USER: ${{ secrets.TOLINO_USER }}
         TOLINO_PASSWORD: ${{ secrets.TOLINO_PASSWORD }}
         TOLINO_PARTNER_SHOP: ${{ secrets.TOLINO_PARTNER_SHOP }}
+        GECKOWEBDRIVER: /usr/local/share/gecko_driver
       run: poetry run pytest tests/ -vv --color=yes


### PR DESCRIPTION
Seems like the tag `ubuntu-latest` was changed to 22 instead of 20 on 2022-11-19, see [here](https://github.com/actions/runner-images#available-images). Ubuntu 22.04 seems to not have geckodriver available in `PATH` which causes the pipeline to fail.

This PR pins the usage of ubuntu 20.04 to remedy this issue. Not 100% but maybe [this PR](https://github.com/actions/runner-images/pull/6528) would allow usage of geckodriver in 22. Thus I assume it is likely that in the future geckodriver will also be available in 22.