### PR TITLE
add option not to assert that the title was found

### DIFF
--- a/zeit_on_tolino/tolino.py
+++ b/zeit_on_tolino/tolino.py
@@ -160,6 +160,11 @@ def _upload(webdriver: WebDriver, file_path: Path, e_paper_title: str) -> None:
     WebDriverWait(webdriver, Delay.medium).until(
         EC.element_to_be_clickable((By.CSS_SELECTOR, 'span[data-test-id="library-myBooks-titles-list-0-title"]'))
     )
+    # Option to not assert, that the title is found to allow for special characters in title
+    if "TOLINO_NO_ASSERT" in os.environ:
+        if e_paper_title not in webdriver.page_source:
+            log.error(f"Title '{e_paper_title}' not found in page source!")
+        return
     assert e_paper_title in webdriver.page_source, f"Title '{e_paper_title}' not found in page source!"
     log.info(f"book title '{e_paper_title}' is present.")
     log.info("successfully uploaded ZEIT e-paper to tolino cloud.")


### PR DESCRIPTION
Thank you again for this great code.
I want to reuse this for another project to use the tolino upload functionality.
Sometimes, there are special characters in the title, like ampersands &, and this
always throws an error as the & are somehow masked in the html code of the site.
It would be great if it could be an option (set by a secret) to disable the assert

For interest, this is the code to use `zeit-on-tolino` as a package for tolino upload:

```python
    epub_filename = "path/to/epub/file"
    title = "great story & cool characters"
    sys.path.insert(0, "./zeit-on-tolino/")
    env_vars = importlib.import_module("zeit_on_tolino.env_vars")
    tolino = importlib.import_module("zeit_on_tolino.tolino")
    web = importlib.import_module("zeit_on_tolino.web")
    env_vars.verify_env_vars_are_set()
    env_vars.verify_configured_partner_shop_is_supported()
    webdriver = web.get_webdriver()
    tolino._login(webdriver)
    tolino._upload(webdriver, epub_filename, title)
    webdriver.quit()
```

My other project uses this to pull bedtime stories from a public website and put them 
as epub on my tolino. I asked the owner of the website if I could publish the code and
they declined, so I want to respect that and use it only for me personally.
